### PR TITLE
Fix clipboard alias commands in .bashrc for correct xclip usage

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -32,8 +32,8 @@ fi
 # Platform specific clipboard setup {{{
 if [ "Linux" = "$(uname)" ]; then
   if command -v xclip >/dev/null 2>&1; then
-	alias pbcopy='xclip -selection clipboard c'
-	alias pbpaste='xclip -selection clipboard c -o'
+	alias pbcopy='xclip -selection clipboard'
+	alias pbpaste='xclip -selection clipboard -o'
   else
 	echo "Warning: xclip not found. Clipboard functionality will be limited."
 	echo "You can install it via: sudo apt install xclip"


### PR DESCRIPTION
This pull request makes a minor fix to the clipboard alias definitions in the `.bashrc` file for Linux systems. The change corrects the arguments passed to `xclip` for the `pbcopy` and `pbpaste` aliases to ensure they work as intended.