### PR TITLE
Add VCS info support to Zsh prompt for better version control visibility

### DIFF
--- a/.zsh/.zshrc
+++ b/.zsh/.zshrc
@@ -24,6 +24,13 @@ sed -e 's/:/\n/g' <(echo "$PATH")
 autoload -Uz colors && colors
 autoload -Uz compinit && compinit
 autoload -Uz bashcompinit && bashcompinit
+autoload -Uz vcs_info
+precmd_vcs_info() { vcs_info }
+precmd_functions+=( precmd_vcs_info )
+setopt prompt_subst
+RPROMPT='${vcs_info_msg_0_}'
+# PROMPT='${vcs_info_msg_0_}%# '
+zstyle ':vcs_info:git:*' formats '%b'
 
 # Autoload user defined completion functions
 autoload -Uz gitutils && gitutils


### PR DESCRIPTION
This pull request enhances the shell prompt in `.zshrc` by integrating Git branch information into the right prompt (RPROMPT) using `vcs_info`. This will allow you to see the current Git branch directly in your terminal prompt, improving your workflow when working with Git repositories.

Prompt and Git integration:

* Added `vcs_info` autoload and set up a `precmd` hook to update Git information before each prompt.
* Enabled prompt substitution and configured `RPROMPT` to display the current Git branch using `vcs_info`.
* Customized the Git branch display format in the prompt via `zstyle`.