### PR TITLE
Fix Neovim starting warning of The require('lspconfig') "framework" i…

### DIFF
--- a/.config/nvim/lua/plugins/lsp-config.lua
+++ b/.config/nvim/lua/plugins/lsp-config.lua
@@ -23,8 +23,6 @@ return {
       vim.env.PATH = vim.fn.expand "~/.ghcup/bin" .. ":" .. vim.env.PATH
       local ghcup_hls = vim.fn.expand "~/.ghcup/bin/haskell-language-server-wrapper"
 
-      local lspconfig = require "lspconfig"
-
       require("mason").setup()
       local mlsp = require "mason-lspconfig"
       mlsp.setup {
@@ -40,7 +38,7 @@ return {
         if server == "rust_analyzer" then
           return -- avoid conflict with rustaceanvim
         end
-        lspconfig[server].setup {
+        vim.lsp.config[server] = {
           capabilities = capabilities,
           -- on_attach = function(client, bufnr) ... end,
           -- settings = { ... },
@@ -56,13 +54,13 @@ return {
           end,
           -- per-server overrides as needed:
           ["lua_ls"] = function()
-            lspconfig.lua_ls.setup {
+            vim.lsp.config.lua_ls = {
               capabilities = capabilities,
               settings = { Lua = { diagnostics = { globals = { "vim" } } } },
             }
           end,
           ["hls"] = function()
-            lspconfig.hls.setup {
+            vim.lsp.config.hls = {
               cmd = { ghcup_hls, "--lsp" },
               filetypes = { "haskell", "lhaskell", "cabal" },
               capabilities = capabilities,


### PR DESCRIPTION
…s deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead. Feature will be removed in nvim-lspconfig v3.0.0
This pull request refactors the way Language Server Protocol (LSP) servers are configured in the Neovim setup by switching from direct use of the `lspconfig` plugin to configuring servers through `vim.lsp.config`. This change streamlines server setup and paves the way for more consistent configuration management.

**LSP Configuration Refactor:**

* Removed the direct import and usage of the `lspconfig` plugin, reducing plugin dependency in the configuration.
* Updated the general LSP server setup to assign configurations to `vim.lsp.config[server]` instead of calling `lspconfig[server].setup`.

**Per-server Configuration Updates:**

* Changed the configuration for the `lua_ls` and `hls` servers to use `vim.lsp.config` assignments rather than `lspconfig.<server>.setup` calls, ensuring consistency with the new approach.