### PR TITLE
Fix: in Neovim 0.11+ language server does not need to be setup in lsp…

### DIFF
--- a/.config/nvim/lua/plugins/lsp-config.lua
+++ b/.config/nvim/lua/plugins/lsp-config.lua
@@ -70,7 +70,6 @@ return {
             }
           end,
         }
-      else
       end
     end,
   },


### PR DESCRIPTION
… configuration plusins.